### PR TITLE
Add support for hiding left bounds, notes, note cursor, and Tromboner model

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "GameplayUIReducer.sln"
+}

--- a/GameplayUIReducer.sln
+++ b/GameplayUIReducer.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GameplayUIReducer", "GameplayUIReducer.csproj", "{B225F713-75E5-47F2-8EBC-0B6965B5E89D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B225F713-75E5-47F2-8EBC-0B6965B5E89D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B225F713-75E5-47F2-8EBC-0B6965B5E89D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B225F713-75E5-47F2-8EBC-0B6965B5E89D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B225F713-75E5-47F2-8EBC-0B6965B5E89D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0332299C-88DC-48F9-97DE-7B6AAE876D67}
+	EndGlobalSection
+EndGlobal

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,6 +1,6 @@
 /*
     COPYRIGHT NOTICE:
-    © 2022 Thomas O'Sullivan - All rights reserved.
+    ï¿½ 2022 Thomas O'Sullivan - All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -97,9 +97,12 @@ namespace GameplayUIReducer
             ElementPaths.Add("Health Meter", "HealthMask");
             ElementPaths.Add("Rainbow Borders", null);
             ElementPaths.Add("Longest Combo", "GameplayCanvas/UIHolder/maxcombo");
+            ElementPaths.Add("Left Bounds", "GameplayCanvas/GameSpace/LeftBounds");
             ElementPaths.Add("Note Lines", "GameplayCanvas/GameSpace/NoteLinesHolder");
+            ElementPaths.Add("Notes", "GameplayCanvas/GameSpace/NotesHolder");
             ElementPaths.Add("Lyrics", "GameplayCanvas/GameSpace/LyricsHolder");
             ElementPaths.Add("Note Explosions", "GameplayCanvas/GameSpace/NoteEndExplosions");
+            ElementPaths.Add("Note Cursor", "GameplayCanvas/GameSpace/TargetNote");
             ElementPaths.Add("Multiplier Popup", "GameplayCanvas/Popups/popup_mult");
             ElementPaths.Add("Accuracy Popup", "GameplayCanvas/Popups/popup_text");
             ElementPaths.Add("No Gap Popup", "GameplayCanvas/Popups/no_gap");
@@ -107,6 +110,7 @@ namespace GameplayUIReducer
             ElementPaths.Add("Song Name", "GameplayCanvas/UIHolder/upper_right/Song Name Shadow");
             ElementPaths.Add("Score Counter", "GameplayCanvas/UIHolder/upper_right/ScoreShadow");
             ElementPaths.Add("Time Elapsed", "GameplayCanvas/UIHolder/time_elapsed");
+            ElementPaths.Add("Tromboner Model", "3dModelCamera");
         }
 
         private new static ManualLogSource Logger { get; set; }


### PR DESCRIPTION
This PR adds support for hiding the left bounds (the bar the note cursor lives on), notes, note cursor, and Tromboner model. While there's little practical use in hiding the notes and note cursor under normal gameplay, it does provide more flexability when it comes to taking screenshots and videos of custom backgrounds. I thought about adding an option to hide the "AutoToot Enabled" text as well for the same reason, although that would obviously defeat the purpose of the text in other situations. Perhaps such an option could be added *if* all the other UI elements have been hidden (or at least the key gameplay elements), but that's probably best saved for a different PR.

The Tromboner model was also added to the list since I saw a request or two for this (doesn't impact extra Tromboners in custom backgrounds).

Hiding the notes also makes for a pretty unique way of playing the game, especially if you've played a chart for enough time to have memorised all the patterns.